### PR TITLE
fix/PLAYV-1183 #comment PLAYV-1183 "카드 flex로 변경 및 col-span-3 추가"

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -5,7 +5,7 @@ type CardProps = {
 };
 
 const Card: React.FC<CardProps> = ({ children }) => (
-  <div className="w-[343px] grid gap-y-5 cursor-pointer p-5 rounded-xl border border-gray-300 bg-tertiary hover:border-2 hover:border-primary hover:m-[-1px] hover:bg-white hover:active:border hover:active:border-gray-300 hover:active:bg-tertiary hover:active:m-0">
+  <div className="flex flex-col col-span-3 gap-y-5 cursor-pointer p-5 rounded-xl border border-gray-300 bg-tertiary hover:border-2 hover:border-primary hover:m-[-1px] hover:bg-white hover:active:border hover:active:border-gray-300 hover:active:bg-tertiary hover:active:m-0">
     {children}
   </div>
 );


### PR DESCRIPTION
# Issue
link url
[[C_UIUX] Mac > Landing 좌우 간격이 상이함](https://bclabs.atlassian.net/browse/PLAYV-1183)
# What fix
- grid -> flex로 교체하여 컨텐츠 넘침 방지
- 고정너비 -> col-span-3 로 교체

# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
