### PR TITLE
Bugfix/playv 1217 얼럿 텍스트정렬 왼쪽으로 수정

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -73,7 +73,7 @@ const Alert: React.FC<AlertProps> = ({
       <div className="flex gap-x-3">
         <div>{renderIcon()}</div>
         <div className="text-sm flex flex-col justify-center">
-          <p className={`${alertText} font-medium break-words`}>{text}</p>
+          <p className={`${alertText} font-medium break-words text-left`}>{text}</p>
           {subText && <p className={`mt-2 break-words ${alertSubText}`}>{subText}</p>}
         </div>
         {closeBtn && (

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -71,7 +71,7 @@ const TextInput: React.FC<TextInputProps> = ({
       />
       {miniButton && (
         <div className="absolute top-1.5 bottom-1.5 right-2.5">
-          <Button color="secondary" size="small" handleClick={handleMiniButtonClick}>
+          <Button type="button" color="secondary" size="small" handleClick={handleMiniButtonClick}>
             {miniButton}
           </Button>
         </div>


### PR DESCRIPTION
# Issue
link url
[[C_UIUX] Header > 마우스 호버 > 발생한 툴팁 문구 줄바꿈이 디자인과 상이함](https://bclabs.atlassian.net/browse/PLAYV-1217)
# What fix
- 얼럿의 제목 텍스트를 왼쪽으로 정렬했습니다.
- textInput 의 버튼 타입을 button으로 수정했습니다.
# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
