### PR TITLE
fix/PLAYV-1236 #comment PLAYV-1236 "meut-preset.cjs 에 text-xs line-he…

### DIFF
--- a/meut-preset.cjs
+++ b/meut-preset.cjs
@@ -44,6 +44,9 @@ module.exports = {
         'light-200': '0px 12px 12px rgba(0, 83, 125, 0.1)',
         'light-300': '0px 24px 24px rgba(0, 83, 125, 0.1)',
         'light-400': '0px 48px 48px rgba(0, 83, 125, 0.1)',
+      },
+      fontSize: {
+        'xs': ['12px',{ lineHeight: '20px' }],
       }
     },
   },


### PR DESCRIPTION
…ight 기본값 16px에서 20px으로 변경"

# Issue
link url
[[FRONT-END] Typography text-xs 컴포넌트 추가(커스텀)](https://bclabs.atlassian.net/browse/PLAYV-1236)

# What fix
- tailwindcss 에서 기본으로 제공하는 클래스인 text-xs 의 line-height 값을 기본값 16px 에서 20px로 덮어씌웠습니다.

# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
