### PR TITLE
PLAYV-1316 #comment "카드에 optional className 프롭으로 추가"

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -3,36 +3,40 @@ import React from 'react';
 type CardProps = {
   children: React.ReactNode;
   color?: string;
+  className?: string;
 };
 
-const Card: React.FC<CardProps> = ({ children, color }) => {
+const Card: React.FC<CardProps> = ({ children, color, className }) => {
   let cardColor = 'bg-tertiary';
   let cardHoverColor = 'hover:bg-white';
-  let cardActiveColor = 'hover:active:bg-tertiary'
-  let borderHoverColor = 'hover:border-primary'
+  let cardActiveColor = 'hover:active:bg-tertiary';
+  let borderHoverColor = 'hover:border-primary';
   switch (color) {
     case 'BuyRequest':
       cardColor = 'bg-gradient-buy';
       cardHoverColor = 'hover:bg-gradient-buy-hover';
-      cardActiveColor = 'hover:active:bg-gradient-buy'
+      cardActiveColor = 'hover:active:bg-gradient-buy';
       break;
     case 'BuySell':
       cardColor = 'bg-gradient-sell';
       cardHoverColor = 'hover:bg-gradient-sell-hover';
-      cardHoverColor = 'hover:active:bg-gradient-sell'
-      borderHoverColor ='hover:border-pink-600'
+      cardHoverColor = 'hover:active:bg-gradient-sell';
+      borderHoverColor = 'hover:border-pink-600';
       break;
     default:
       cardColor = 'bg-tertiary';
       cardHoverColor = 'hover:bg-white';
-      cardActiveColor = 'hover:active:bg-tertiary'
+      cardActiveColor = 'hover:active:bg-tertiary';
       break;
   }
 
   return (
-  <div className={`flex flex-col col-span-3 gap-y-5 cursor-pointer p-5 rounded-xl border border-gray-300 ${cardColor} hover:border-2 ${borderHoverColor} hover:m-[-1px] ${cardHoverColor} hover:active:border hover:active:border-gray-300 ${cardActiveColor} hover:active:m-0`}>
-    {children}
-  </div>
-)};
+    <div
+      className={`flex flex-col col-span-3 w-[343px] gap-y-5 cursor-pointer p-5 rounded-xl border border-gray-300 ${cardColor} hover:border-2 ${borderHoverColor} hover:m-[-1px] ${cardHoverColor} hover:active:border hover:active:border-gray-300 ${cardActiveColor} hover:active:m-0 ${className}`}
+    >
+      {children}
+    </div>
+  );
+};
 
 export default Card;


### PR DESCRIPTION
# Issue
link url

# What fix
- Manual Strategies 페이지에서 사용되는 카드의 너비가 달라(기존: 343px , Manual Strategies page: 374px) className을 추가하여 너비를 수정하여 사용할 수 있도록 변경했습니다.
# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
