### PR TITLE
PLAYV-1482 #comment "meut - Badge_Label 컴포넌트 추가"

### DIFF
--- a/src/components/Badge/BadgeLabel.tsx
+++ b/src/components/Badge/BadgeLabel.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+interface BadgeLabelProps {
+  text: string;
+  status: 'attention' | 'disabled' | 'warning' | 'information';
+  className: string;
+}
+
+const BadgeLabel = ({ text, status, className }: BadgeLabelProps) => {
+  let bgColor;
+  let txtColor;
+
+  switch (status) {
+    case 'attention':
+      bgColor = '#FEF3C7'; // 'bg-yellow-100'
+      txtColor = '#92400E'; // 'text-yellow-800';
+      break;
+    case 'disabled':
+      bgColor = '#F3F4F6'; // 'bg-gray-100';
+      txtColor = '#1F2937'; // 'text-gray-800';
+      break;
+    case 'warning':
+      bgColor = '#FEE2E2'; // 'bg-red-100';
+      txtColor = '#991B1B'; // 'text-red-800';
+      break;
+    case 'information':
+      bgColor = '#DBEAFE'; // 'bg-blue-100';
+      txtColor = '#1E40AF'; // 'text-blue-800';
+      break;
+    default:
+      bgColor = '#FEF3C7'; // 'bg-yellow-100'
+      txtColor = '#92400E'; // 'text-yellow-800';
+  }
+
+  return (
+    <svg
+      width="146"
+      height="144"
+      viewBox="0 0 146 144"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <g clipPath="url(#clip0_3050_42676)">
+        <rect
+          x="29.2842"
+          y="-29"
+          width="206"
+          height="40"
+          transform="rotate(45 29.2842 -29)"
+          fill={bgColor}
+        />
+        <text
+          x="92%"
+          y="-6%"
+          transform="rotate(45 29.2842 -29)"
+          dominantBaseline="middle"
+          textAnchor="middle"
+          fill={txtColor}
+          fontWeight="500"
+        >
+          {text}
+        </text>
+      </g>
+      <defs>
+        <clipPath id="clip0_3050_42676">
+          <rect width="146" height="144" fill="white" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+};
+
+export default BadgeLabel;

--- a/src/components/Badge/index.ts
+++ b/src/components/Badge/index.ts
@@ -1,0 +1,4 @@
+import BadgeLabel from './BadgeLabel';
+
+// TODO: Badge_TOP3 만들면 export { BadgeLabel, BadgeTop3 } 로 export
+export default BadgeLabel;


### PR DESCRIPTION
# Issue
link url
[[FRONT-END] 공통-Badge 타입 추가](https://bclabs.atlassian.net/browse/PLAYV-1482)

# What fix
- 대각 벳지 컴포넌트 생성했습니다.
- text 프롭으로 뱃지 안의 텍스트를 바꿀 수 있습니다.
- status 로 뱃지 색깔을 바꿀 수 있습니다.
- className 을 추가하여 뱃지 위치를 조절할 수 있습니다.

# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
![스크린샷 2023-02-20 오후 2 32 59](https://user-images.githubusercontent.com/114374519/220017543-e1c8935b-9c71-407f-8316-7a525fd05fb5.png)
