### PR TITLE
Bugfix/playv 1419 chip

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -14,7 +14,7 @@ const Chip: React.FC<ChipProps> = ({ label, selected, count, handleClick, classN
     className={`group inline-flex items-center rounded-full px-4 py-2 cursor-pointer ${
       selected
         ? 'bg-primary text-onPrimary font-semibold'
-        : 'bg-tertiary text-base font-medium text-onTertiary hover:bg-secondary focus:bg-primary focus:text-onPrimary focus:font-semibold'
+        : 'bg-tertiary text-base font-medium text-onTertiary hover:bg-secondary'
     } ${className || ''}`}
   >
     {label}

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -18,7 +18,7 @@ const Chip: React.FC<ChipProps> = ({ label, selected, count, handleClick, classN
     } ${className || ''}`}
   >
     {label}
-    {count ? (
+    {!!count || count === 0 ? (
       <span
         className={`px-3 py-1 ml-1 rounded-[10px] text-onTertiary text-xs font-medium ${
           selected ? 'bg-white' : 'bg-tertiary group-focus:bg-white'

--- a/src/stories/Chip.stories.tsx
+++ b/src/stories/Chip.stories.tsx
@@ -21,5 +21,5 @@ export const selected = Template.bind({});
 selected.args = {
   selected: true,
   label: 'All Strategies',
-  count: 18
+  count: 0
 };


### PR DESCRIPTION
# Issue
[link url](https://bclabs.atlassian.net/browse/PLAYV-1419)

# What fix
칩 카운트 0일때 카운트 영역 표시 안 되는 버그 픽스했습니다 
포커스 스타일 제거했습니다(셀렉트 변경되었을 때 이전 포커스가 남아있어서 두개 선택된 것 같은 버그를 픽스하기 위해)
# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
