### PR TITLE
PLAYV-1700 add: Tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import './style.css';
+
+type Content = {
+  title: string;
+  description: string;
+};
+
+type TextInputProps = {
+  content: Content[];
+};
+
+const Tooltip: React.FC<TextInputProps> = ({ content }: TextInputProps) => {
+  return (
+    <div className="relative max-w-[405px] w-max bg-gray-50 rounded-lg shadow-md break-all">
+      {content.map(({ title, description }, index) => (
+        <div className="py-4 px-6 flex gap-x-4 relative">
+          {index !== content.length - 1 && (
+            <div
+              className={`absolute top-4 left-[43.5px] mt-0.5 h-full w-0.5 bg-emerald-500`}
+              aria-hidden="true"
+            />
+          )}
+          <div className="flex h-10 w-10 z-10 items-center justify-center rounded-full bg-emerald-500">
+            <span className="text-gray-50 text-sm font-medium">0{index + 1}</span>
+          </div>
+          <div className="max-w-[301px]">
+            <p className="text-xs font-semibold text-emerald-500">{title}</p>
+            <p className="text-sm font-medium text-neutral">{description}</p>
+          </div>
+        </div>
+      ))}
+      <div className="absolute -bottom-5 left-6 bg-gray-50 triangle" />
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -8,11 +8,14 @@ type Content = {
 
 type TextInputProps = {
   content: Content[];
+  children?: React.ReactNode;
 };
 
-const Tooltip: React.FC<TextInputProps> = ({ content }: TextInputProps) => {
+const Tooltip: React.FC<TextInputProps> = ({ content, children }: TextInputProps) => {
   return (
     <div className="relative max-w-[405px] w-max bg-gray-50 rounded-lg shadow-md break-all">
+      {/* 툴팁은 제일 최상위 div만 쓰이고 보여줄 내용은 children으로 받아서 아래 주석풀어서 쓰시면됩니다. 현재 아래에 작성된 내용은 퀀트카드에 쓰일 툴팁을 만들어 놓을 곳 이 없어서 여기에 만들어놨습니다. */}
+      {/* {children} */}
       {content.map(({ title, description }, index) => (
         <div className="py-4 px-6 flex gap-x-4 relative">
           {index !== content.length - 1 && (

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,0 +1,3 @@
+import Tooltip from './Tooltip';
+
+export default Tooltip;

--- a/src/components/Tooltip/style.css
+++ b/src/components/Tooltip/style.css
@@ -1,0 +1,5 @@
+.triangle {
+    clip-path: polygon(100% 0, 0 0, 50% 100%);
+    width: 24px;
+    height: 24px;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,7 +10,8 @@ import Checkbox from './Checkbox';
 import Dropdown from './Dropdown';
 import Chip from './Chip';
 import TextareaInput from './TextareaInput';
-import BadgeLabel from './Badge'
+import BadgeLabel from './Badge';
+import Tooltip from './Tooltip';
 
 export {
   Button,
@@ -25,4 +26,5 @@ export {
   Chip,
   TextareaInput,
   BadgeLabel,
+  Tooltip,
 };

--- a/src/stories/Tooltip.stories.tsx
+++ b/src/stories/Tooltip.stories.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Tooltip from '../components/Tooltip/Tooltip';
+
+export default {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+} as ComponentMeta<typeof Tooltip>;
+
+const Template: ComponentStory<typeof Tooltip> = (args) => <Tooltip {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  content: [
+    {
+      title: 'title1',
+      description:
+        'description1 description1 description1 description1 description1 description1 description1 description1',
+    },
+    {
+      title: 'title2',
+      description: 'description2 description2 description2',
+    },
+    {
+      title: 'title3',
+      description: 'description3 description3 hello coinvestor hihihi',
+    },
+    {
+      title: 'title4',
+      description:
+        'description4 넷플릭스보면서 코딩중 예시 텍스트 안녕하세요 코인베스터 고고고고고고고고고 코인베스터 코인베스터 코인베스터 코인베스터 코인베스터',
+    },
+  ],
+};


### PR DESCRIPTION
# Issue
link url https://bclabs.atlassian.net/browse/PLAYV-1700

# What fix
- 퀀트 카드에서 쓰일 툴팁 미리 만듦
- 추후에 툴팁 풍선만 남기고 현재 임시로 들어가있는 내부 코드(퀀트 카드 툴팁내용)는 드러내서 리뉴얼에서 children으로 내려주도록 코드 수정필요 (최종적으로는 툴팁 풍선만 남아서 다른 툴팁으로도 재사용되도록)
