### PR TITLE
CNVSTR-2012 fix: TextInput focus앞에 hover 삭제, placeholder font-medium 추가

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -38,15 +38,15 @@ const Button: React.FC<ButtonProps> = ({
   switch (color) {
     case 'primary':
       btnColor =
-        'bg-primary text-onPrimary hover:bg-primary-hover active:bg-primary-active disabled:hover:bg-primary';
+        'bg-primary text-onPrimary hover:bg-primary-hover active:bg-primary-focus disabled:hover:bg-primary';
       break;
     case 'secondary':
       btnColor =
-        'bg-secondary text-onSecondary hover:bg-secondary-hover active:bg-secondary-active disabled:hover:bg-secondary';
+        'bg-secondary text-onSecondary hover:bg-secondary-hover active:bg-secondary-focus disabled:hover:bg-secondary';
       break;
     case 'tertiary':
       btnColor =
-        'bg-tertiary text-onTertiary hover:bg-tertiary-hover active:bg-tertiary-active disabled:hover:bg-tertiary';
+        'bg-tertiary text-onTertiary hover:bg-tertiary-hover active:bg-tertiary-focus disabled:hover:bg-tertiary';
       break;
     default:
       throw Error('invalid color value');

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -69,10 +69,10 @@ const TextInput: React.FC<TextInputProps> = ({
           maxLength={maxLength}
           name={name}
           id={name}
-          className={`w-full h-12 p-3 rounded focus:ring-0 placeholder:text-neutral ${
+          className={`w-full h-12 p-3 rounded focus:ring-0 placeholder:text-neutral placeholder:font-medium ${
             errorMessage
               ? 'border-2 border-warning focus:border-warning'
-              : 'border border-gray-300 hover:outline hover:outline-[3px] hover:outline-secondary-hover hover:focus:outline-0 focus:border-2 focus:border-primary disabled:hover:outline-0'
+              : 'border border-gray-300 hover:outline hover:outline-[3px] hover:outline-secondary-hover focus:outline-0 focus:border-2 focus:border-primary disabled:hover:outline-0'
           }`}
           style={{ paddingRight: (miniButton || currency) && `${rightAddedWidth}px` }}
           disabled={disabled}


### PR DESCRIPTION
# Issue
link url https://bclabs.atlassian.net/browse/CNVSTR-2012

# What fix
- TextInput focus앞에 hover 삭제, placeholder font-medium 추가
- Button active 색상 수정
- 피그마 https://www.figma.com/file/mDHKwkELe0uoMbtTUYsOHU/%5B%EB%94%94%EC%9E%90%EC%9D%B8%5D-Investor-Web-Design-System-v.1.0.0?node-id=167%3A8077&t=whErUAmx5jIPxjOn-1
![스크린샷 2023-04-05 오후 4 16 49](https://user-images.githubusercontent.com/100259912/230008694-619706b2-778f-4e48-8c82-98ff90680191.png)
![스크린샷 2023-04-05 오후 6 48 09](https://user-images.githubusercontent.com/100259912/230045502-d5da67f5-3a1d-4bf3-8e01-2b79c9f21d74.png)
