### PR TITLE
CNVSTR-2044 #comment "ProfilePhoto에 rounded-[8px] 속성 추가"

### DIFF
--- a/src/components/ProfilePhoto/ProfilePhoto.tsx
+++ b/src/components/ProfilePhoto/ProfilePhoto.tsx
@@ -4,8 +4,9 @@ import './style.css';
 type ProfilePhotoProps = {
   size: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | '2x-large';
   imageFile: string;
+  rounded?: boolean;
 };
-const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ size, imageFile }: ProfilePhotoProps) => {
+const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ size, imageFile, rounded }: ProfilePhotoProps) => {
   let profilePhotoSize;
   switch (size) {
     case 'x-small':
@@ -34,7 +35,7 @@ const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ size, imageFile }: ProfileP
     <img
       src={imageFile}
       alt="profile"
-      className={`picture-style rounded-full ${profilePhotoSize}`}
+      className={`picture-style ${rounded ? "rounded-[8px]" : "rounded-full"} ${profilePhotoSize}`}
     />
   );
 };

--- a/src/stories/ProfilePhoto.stories.tsx
+++ b/src/stories/ProfilePhoto.stories.tsx
@@ -15,3 +15,10 @@ Default.args = {
   size: 'large',
   imageFile: 'https://avatars.githubusercontent.com/u/67389821?v=4',
 };
+
+export const Rounded = Template.bind({});
+Rounded.args = {
+  size: 'medium',
+  imageFile: 'https://avatars.githubusercontent.com/u/67389821?v=4',
+  rounded: true,
+}


### PR DESCRIPTION
# Issue
link url
https://bclabs.atlassian.net/browse/CNVSTR-2044

# What fix
- ProfileImage 에 rounded-[8px] 옵션을 추가했습니다.
- rounded 옵션이 들어간 스토리북 추가하였습니다.
- rounded를 추가하지 않았을 때 rounded-full / 추가하였을 때 rounded-[8px] 입니다.

- 사용예시
```jsx
          <ProfilePhoto
            size="medium"
            imageFile={imageURL || '/images/Header/Avatar_Profile_Default.svg'}
            rounded
          />
```

# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
| rounded | rounded 없을 떄(기본) |
|---|---|
|![스크린샷 2023-04-06 오후 5 05 44](https://user-images.githubusercontent.com/114374519/230314405-241fae39-50d6-4aaa-be46-0747523e2f3c.png) | ![스크린샷 2023-04-06 오후 5 06 02](https://user-images.githubusercontent.com/114374519/230314449-e1f8a50d-2659-48e0-88b6-68ea88e7a3cc.png) |


