### PR TITLE
CNVSTR-2062 #comment fix: [meut] Alert 컴포넌트

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -121,7 +121,7 @@ const Alert: React.FC<AlertProps> = ({
           {subText && (
             <p
               className={`mt-2 break-words ${alertSubText} ${
-                subTextSmaller ? 'text-xs' : 'text-sm'
+                subTextSmaller ? 'text-xs leading-5' : 'text-sm'
               }`}
             >
               {subText}


### PR DESCRIPTION
# Issue
- link url https://bclabs.atlassian.net/browse/CNVSTR-2062
- [디자인 피그마 링크](https://www.figma.com/file/mDHKwkELe0uoMbtTUYsOHU/%5B%EB%94%94%EC%9E%90%EC%9D%B8%5D-Investor-Web-Design-System-v.1.0.0?node-id=608%3A12358&t=6rRp9dkQEhzIoEym-1)

# What fix
- Alert 컴포넌트에 leading-5 클래스를 추가

# Caution
- 해당 PR이 먼저 머지되고 나서 [코인베스터 PR](https://github.com/bclabs-org/coinvestor_investor-frontend/pull/908)이 머지되어야 합니다

# Optional(eg. screenshot)
## 하기 이미지에서 제목 아래 문구에 leading-5가 적용됐습니다
![image](https://user-images.githubusercontent.com/117154084/231685391-34e10674-4af2-4d52-9fad-bf469cba464a.png)
