### PR TITLE
Cnvstr 2069 툴팁 디자인 변경 및 스텝 과 분리

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,41 +1,20 @@
 import React from 'react';
-import './style.css';
 
-type Content = {
-  title: string;
-  description: string;
+type TooltipProps = {
+  tooltipText: string;
+  containerClassName?: string;
 };
 
-type TextInputProps = {
-  content: Content[];
-  children?: React.ReactNode;
-};
-
-const Tooltip: React.FC<TextInputProps> = ({ content, children }: TextInputProps) => {
-  return (
-    <div className="relative max-w-[405px] w-max bg-gray-50 rounded-lg shadow-md break-all">
-      {/* 툴팁은 제일 최상위 div만 쓰이고 보여줄 내용은 children으로 받아서 아래 주석풀어서 쓰시면됩니다. 현재 아래에 작성된 내용은 퀀트카드에 쓰일 툴팁을 만들어 놓을 곳 이 없어서 여기에 만들어놨습니다. */}
-      {/* {children} */}
-      {content.map(({ title, description }, index) => (
-        <div className="py-4 px-6 flex gap-x-4 relative">
-          {index !== content.length - 1 && (
-            <div
-              className={`absolute top-4 left-[43.5px] mt-0.5 h-full w-0.5 bg-emerald-500`}
-              aria-hidden="true"
-            />
-          )}
-          <div className="flex h-10 w-10 z-10 items-center justify-center rounded-full bg-emerald-500">
-            <span className="text-gray-50 text-sm font-medium">0{index + 1}</span>
-          </div>
-          <div className="max-w-[301px]">
-            <p className="text-xs font-semibold text-emerald-500">{title}</p>
-            <p className="text-sm font-medium text-neutral">{description}</p>
-          </div>
-        </div>
-      ))}
-      <div className="absolute -bottom-5 left-6 bg-gray-50 triangle" />
+const Tooltip: React.FC<TooltipProps> = ({ tooltipText, containerClassName }: TooltipProps) => (
+  <div className={`absolute -bottom-1 -left-7 drop-shadow-lg  ${containerClassName || ''}`}>
+    <div className="w-[343px] px-4 py-3 rounded-[8px] bg-gray-700 text-xs text-gray-200">
+      {tooltipText}
     </div>
-  );
-};
+    <div
+      className="relative bottom-[23px] left-6 bg-gray-700 w-6 h-9"
+      style={{ clipPath: 'polygon(50% 50%, 100% 50%, 50% 100%, 0 50%)' }}
+    />
+  </div>
+);
 
 export default Tooltip;

--- a/src/components/TooltipWithSteps/TooltipWithSteps.tsx
+++ b/src/components/TooltipWithSteps/TooltipWithSteps.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+type Content = {
+  title: string;
+  description: string;
+};
+
+type TooltipProps = {
+  content?: Content[];
+  containerClassName?: string;
+};
+
+const TooltipWithSteps: React.FC<TooltipProps> = ({
+  content,
+  containerClassName,
+}: TooltipProps) => (
+  <div className={`absolute drop-shadow-lg ${containerClassName}`}>
+    <div
+      className="w-max rounded-[8px] bg-gray-700 text-xs text-gray-200"
+    >
+      {content &&
+        content.length > 0 &&
+        content.map(({ title, description }, index) => (
+          <>
+            <div key={`step_${title}`} className="py-4 px-6 flex gap-x-4 relative">
+              {index !== content.length - 1 && (
+                <div
+                  className={`absolute top-4 left-[43.5px] mt-0.5 h-full w-0.5 bg-emerald-500`}
+                  aria-hidden="true"
+                />
+              )}
+              <div className="flex h-10 w-10 z-10 items-center justify-center rounded-full bg-emerald-500">
+                <span className="text-gray-50 text-sm font-medium">0{index + 1}</span>
+              </div>
+              <div className="max-w-[301px]">
+                <p className="text-xs font-semibold text-emerald-500">{title}</p>
+                <p className="text-sm font-medium text-neutral">{description}</p>
+              </div>
+            </div>
+          </>
+        ))}
+    </div>
+    <div
+      className="relative bottom-[23px] left-6 bg-gray-700 w-6 h-9"
+      style={{ clipPath: 'polygon(50% 50%, 100% 50%, 50% 100%, 0 50%)' }}
+    />
+  </div>
+);
+
+export default TooltipWithSteps;

--- a/src/components/TooltipWithSteps/index.ts
+++ b/src/components/TooltipWithSteps/index.ts
@@ -1,0 +1,3 @@
+import TooltipWithSteps from './TooltipWithSteps';
+
+export default TooltipWithSteps;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,6 +12,7 @@ import Chip from './Chip';
 import TextareaInput from './TextareaInput';
 import BadgeLabel from './Badge';
 import Tooltip from './Tooltip';
+import TooltipWithSteps from './TooltipWithSteps';
 import Table from './Table';
 import TwoColumnTable from './TwoColumnTable';
 
@@ -29,6 +30,7 @@ export {
   TextareaInput,
   BadgeLabel,
   Tooltip,
+  TooltipWithSteps,
   Table,
   TwoColumnTable,
 };

--- a/src/stories/Tooltip.stories.tsx
+++ b/src/stories/Tooltip.stories.tsx
@@ -12,24 +12,5 @@ const Template: ComponentStory<typeof Tooltip> = (args) => <Tooltip {...args} />
 
 export const Default = Template.bind({});
 Default.args = {
-  content: [
-    {
-      title: 'title1',
-      description:
-        'description1 description1 description1 description1 description1 description1 description1 description1',
-    },
-    {
-      title: 'title2',
-      description: 'description2 description2 description2',
-    },
-    {
-      title: 'title3',
-      description: 'description3 description3 hello coinvestor hihihi',
-    },
-    {
-      title: 'title4',
-      description:
-        'description4 넷플릭스보면서 코딩중 예시 텍스트 안녕하세요 코인베스터 고고고고고고고고고 코인베스터 코인베스터 코인베스터 코인베스터 코인베스터',
-    },
-  ],
+  tooltipText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
 };

--- a/src/stories/TooltipWithSteps.stories.tsx
+++ b/src/stories/TooltipWithSteps.stories.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import TooltipWithSteps from "../components/TooltipWithSteps";
+
+export default {
+    title: 'Components/TooltipWithSteps',
+    component: TooltipWithSteps,
+} as ComponentMeta<typeof TooltipWithSteps>;
+
+const Template: ComponentStory<typeof TooltipWithSteps> = (args) => <TooltipWithSteps {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+    content: [
+        {
+            title: 'Lorem ipsum dolor sit amet',
+            description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc auctor, nisl eget ultricies lacinia, nisl nisl aliquet nisl, eget aliquet nisl nisl eget nisl. Nunc auctor, nisl eget ultricies lacinia, nisl nisl aliquet nisl, eget aliquet nisl nisl eget nisl.'
+        },
+        {
+            title: 'Lorem ipsum dolor sit amet',
+            description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc auctor, nisl eget ultricies lacinia, nisl nisl aliquet nisl, eget aliquet nisl nisl eget nisl. Nunc auctor, nisl eget ultricies lacinia, nisl nisl aliquet nisl, eget aliquet nisl nisl eget nisl.'
+        },
+        {
+            title: 'Lorem ipsum dolor sit amet',
+            description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc auctor, nisl eget ultricies lacinia, nisl nisl aliquet nisl, eget aliquet nisl nisl eget nisl. Nunc auctor, nisl eget ultricies lacinia, nisl nisl aliquet nisl, eget aliquet nisl nisl eget nisl.'
+        },
+        {
+            title: 'Lorem ipsum dolor sit amet',
+            description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc auctor, nisl eget ultricies lacinia, nisl nisl aliquet nisl, eget aliquet nisl nisl eget nisl. Nunc auctor, nisl eget ultricies lacinia, nisl nisl aliquet nisl, eget aliquet nisl nisl eget nisl.'
+        },
+        {
+            title: 'Lorem ipsum dolor sit amet',
+            description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc auctor, nisl eget ultricies lacinia, nisl nisl aliquet nisl, eget aliquet nisl nisl eget nisl. Nunc auctor, nisl eget ultricies lacinia, nisl nisl aliquet nisl, eget aliquet nisl nisl eget nisl.'
+        },
+    ]
+};


### PR DESCRIPTION
# Issue
link url
[FRONT-END] SDQ > Performance > Price 박스 텍스트 수정 및 툴팁 추가
https://bclabs.atlassian.net/browse/CNVSTR-2069

# What fix
- 변경된 툴팁 디자인 적용했습니다.
- 텍스트만 들어간 툴팁과 Steps 가 들어간 툴팁을 분리하였습니다.
# Caution
eg. 

질문: 지금 당장은 Steps(스크린샷의 숫자가 들어있는 동그라미: ([피그마링크](https://www.figma.com/file/mDHKwkELe0uoMbtTUYsOHU/%5B%EB%94%94%EC%9E%90%EC%9D%B8%5D-Investor-Web-Design-System-v.1.0.0?node-id=6516-59769&t=6DtajOOSdOi1Rurm-4)) 를 사용하지 않아서 기존에 있던 Steps를 분리했는데요, 

이전 코드와 같이
```jsx
<Tooltip>
  {children}
</Tooltip>
```
툴팁 구조를 원래대로 children 에 Steps나 텍스트를 넘겨주고 Steps 가 들어갔을때 툴팁의 스타일 클래스를 변경해주는 코드를 추가하는게 더 나을까요?

# Optional(eg. screenshot)

| 변경 전 | 변경 후 |
|---|---|
| ![스크린샷 2023-04-21 오후 6 08 33](https://user-images.githubusercontent.com/114374519/233596048-9b33b61e-fbb3-457e-905b-98648d59dae8.png) |  ![스크린샷 2023-04-21 오후 6 03 38](https://user-images.githubusercontent.com/114374519/233595209-6e744c45-9fde-4d8a-855e-8011fff14988.png) ![스크린샷 2023-04-21 오후 6 02 23](https://user-images.githubusercontent.com/114374519/233595167-34338baf-c84e-4f5b-8273-3c4d67546ef6.png) |
