### PR TITLE
Cnvstr 2147 [Quant] Safari > Price 툴팁 아이콘 마우스 호버 > 이외의 영역으로 마우스 이동 시 툴팁 자국이 남음

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -6,7 +6,7 @@ type TooltipProps = {
 };
 
 const Tooltip: React.FC<TooltipProps> = ({ tooltipText, containerClassName }: TooltipProps) => (
-  <div className={`absolute -bottom-1 -left-7 drop-shadow-lg  ${containerClassName || ''}`}>
+  <div className={`absolute -bottom-1 -left-7 will-change-[filter] drop-shadow-lg ${containerClassName || ''}`}>
     <div className="w-[343px] px-4 py-3 rounded-[8px] bg-gray-700 text-xs text-gray-200">
       {tooltipText}
     </div>


### PR DESCRIPTION
# Issue
link url
https://bclabs.atlassian.net/browse/CNVSTR-2147
[Quant] Safari > Price 툴팁 아이콘 마우스 호버 > 이외의 영역으로 마우스 이동 시 툴팁 자국이 남음
# What fix
- safari에서 전략 상세 퍼포먼스 영역 툴팁의 drop-shadow 필터 자국이 남지않도록 수정했습니다.
# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
로컬테스트 완료했습니다