### PR TITLE
Cnvstr 2024 [FRONT-END] 공통 > Typography텍스트 Line-height 기존 세팅으로 원상 복귀

### DIFF
--- a/meut-preset.cjs
+++ b/meut-preset.cjs
@@ -45,9 +45,6 @@ module.exports = {
         'light-300': '0px 24px 24px rgba(0, 83, 125, 0.1)',
         'light-400': '0px 48px 48px rgba(0, 83, 125, 0.1)',
       },
-      fontSize: {
-        'xs': ['12px',{ lineHeight: '20px' }],
-      }
     },
   },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",


### PR DESCRIPTION
# Issue
link url
[[FRONT-END] 공통 > Typography텍스트 Line-height 기존 세팅으로 원상 복귀](https://bclabs.atlassian.net/browse/CNVSTR-2024)
# What fix
- 글로벌 세팅에서 text-xs 일때 line-height 20px 을 삭제했습니다.
# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
