### PR TITLE
chore: 배포때문에 올린 버전 원복

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",


### PR DESCRIPTION
# Issue
없음
# What fix
빌드스크립트 문제로 배포가 잘못되고 있었습니다. 
관련 PR: https://github.com/bclabs-org/meut-ui-react/pull/193
해당 부분 수정하고 버전 원복했습니다.

# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
