### PR TITLE
[개발][Quant] Algo strategies 탭 리뉴얼 사전 작업 - 툴팁 스타일링 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -18,7 +18,7 @@ const Tooltip: React.FC<TooltipProps> = ({ tooltipText, containerClassName }: To
             'after:border-t-[13px] after:border-t-gray-700'
         )
       }
-    >경
+    >
       {tooltipText}
     </div>
   </div>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from "classnames";
 
 type TooltipProps = {
   tooltipText: string;
@@ -6,14 +7,20 @@ type TooltipProps = {
 };
 
 const Tooltip: React.FC<TooltipProps> = ({ tooltipText, containerClassName }: TooltipProps) => (
-  <div className={`absolute -bottom-1 -left-7 will-change-[filter] drop-shadow-lg ${containerClassName || ''}`}>
-    <div className="w-[343px] px-4 py-3 rounded-[8px] bg-gray-700 text-xs font-medium leading-5 text-gray-200">
+  <div className={`inline-block will-change-[filter] drop-shadow-lg ${containerClassName || ''}`}>
+    <div
+      className={
+        classNames(
+        'w-[343px] px-4 py-3 rounded-[8px] bg-gray-700 text-xs font-medium leading-5 text-gray-200',
+            'after:w-0 after:h-0 after:absolute after:top-[100%] after:left-[26px]',
+            'after:border-l-[10px] after:border-l-transparent',
+            'after:border-r-[10px] after:border-r-transparent',
+            'after:border-t-[13px] after:border-t-gray-700'
+        )
+      }
+    >경
       {tooltipText}
     </div>
-    <div
-      className="relative bottom-[23px] left-6 bg-gray-700 w-6 h-9"
-      style={{ clipPath: 'polygon(50% 50%, 100% 50%, 50% 100%, 0 50%)' }}
-    />
   </div>
 );
 


### PR DESCRIPTION
# Issue
link url
https://bclabs.atlassian.net/browse/CNVSTR-2300
# What fix
- 툴팁 말풍선 화살표 부분을 가상요소로 변경하여 툴팁 영역이 아닌 부분도 툴팁 영역으로 인식되던 문제를 수정했습니다.
- position 과 left, bottom 클래스를 제거하여 라이브러리를 사용하는 쪽에서 툴팁위치를 변경 할 수 있도록 수정했습니다.
# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
