### PR TITLE
Bugfix/CNVSTR-1946/모달 열린 상태에 마우스 드래그 시, 모달 바깥으로 커서가 나가면 모달 닫히는 문제 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -37,11 +37,7 @@ const Modal: React.FC<ModalProps> = ({
       <Dialog
         as="div"
         className={`relative ${isCoverHeader ? 'z-30' : 'z-10'}`}
-        onClose={() => null}
-        onClick={(e) => {
-          e.stopPropagation();
-          setIsModalOpen(!onOutsideClick);
-        }}
+        onClose={() => setIsModalOpen(!onOutsideClick)}
       >
         <Transition.Child
           as={Fragment}


### PR DESCRIPTION
# Issue
link url
- https://bclabs.atlassian.net/browse/CNVSTR-1946
# What fix
- 모달 열린 상태에서 마우스 클릭한 상태로 모달 영역 바깥으로 마우스가 나갈 시 모달이 닫히는 현상 수정했습니다.
# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
