### PR TITLE
Feat/BM-302/Convert 탭 관련 ButtonsGroup 컴포넌트 공용화

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.3.13",
+  "version": "1.5.0",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.5.0",
+  "version": "1.4.0",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/ButtonsGroup/ButtonsGroup.tsx
+++ b/src/components/ButtonsGroup/ButtonsGroup.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import classNames from 'classnames';
+import './buttonsGroup.css';
+
+type ButtonsGroupContextProps = {
+  onChange: (value: string) => void;
+  selected: string;
+};
+
+const ButtonsGroupContext = React.createContext<ButtonsGroupContextProps>({
+  onChange: () => null,
+  selected: '',
+});
+
+type ButtonsGroupItemProps = {
+  value: string;
+  label: string;
+  children?: React.ReactNode;
+};
+
+const ButtonsGroupItem = ({ value, label, children }: ButtonsGroupItemProps) => {
+  const { onChange, selected } = React.useContext(ButtonsGroupContext);
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(value)}
+      className={classNames(
+        'relative -ml-px py-2 inline-flex items-center flex-1 justify-center',
+        'border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-secondary',
+        'first:rounded-l-md',
+        'last:rounded-r-md',
+        selected === value && 'btn-group-focus'
+      )}
+    >
+      {children || label}
+    </button>
+  );
+};
+
+type ButtonsGroupProps = ButtonsGroupContextProps & {
+  width?: number | 'full';
+  children?: React.ReactNode;
+  className?: string;
+};
+
+const ButtonsGroup = ({
+  onChange,
+  selected,
+  children,
+  width = 336,
+  className,
+}: ButtonsGroupProps) => (
+  <ButtonsGroupContext.Provider value={{ onChange, selected }}>
+    <span
+      className={classNames('isolate flex rounded-md shadow-sm w-full', className)}
+      style={{ maxWidth: width === 'full' ? 'unset' : width }}
+    >
+      {children}
+    </span>
+  </ButtonsGroupContext.Provider>
+);
+
+ButtonsGroup.Item = ButtonsGroupItem;
+
+export default ButtonsGroup;

--- a/src/components/ButtonsGroup/ButtonsGroup.tsx
+++ b/src/components/ButtonsGroup/ButtonsGroup.tsx
@@ -29,7 +29,7 @@ const ButtonsGroupItem = ({ value, label, children }: ButtonsGroupItemProps) => 
         'border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-secondary',
         'first:rounded-l-md',
         'last:rounded-r-md',
-        selected === value && 'btn-group-focus'
+        selected === value && 'btn-group-selected'
       )}
     >
       {children || label}

--- a/src/components/ButtonsGroup/buttonsGroup.css
+++ b/src/components/ButtonsGroup/buttonsGroup.css
@@ -1,0 +1,7 @@
+.btn-group {
+    @apply relative -ml-px inline-flex items-center border border-gray-300 bg-white py-2 text-sm font-medium text-gray-700 hover:bg-secondary;
+}
+
+.btn-group-focus {
+    @apply z-10 border-primary outline-none text-primary-hover bg-secondary;
+}

--- a/src/components/ButtonsGroup/buttonsGroup.css
+++ b/src/components/ButtonsGroup/buttonsGroup.css
@@ -2,6 +2,6 @@
     @apply relative -ml-px inline-flex items-center border border-gray-300 bg-white py-2 text-sm font-medium text-gray-700 hover:bg-secondary;
 }
 
-.btn-group-focus {
+.btn-group-selected {
     @apply z-10 border-primary outline-none text-primary-hover bg-secondary;
 }

--- a/src/components/ButtonsGroup/index.ts
+++ b/src/components/ButtonsGroup/index.ts
@@ -1,0 +1,3 @@
+import ButtonsGroup from './ButtonsGroup';
+
+export default ButtonsGroup;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,11 +20,13 @@ import TextareaInput from './TextareaInput';
 import Toggle from './Toggle';
 import Tooltip from './Tooltip';
 import TooltipWithSteps from './TooltipWithSteps';
+import ButtonsGroup from './ButtonsGroup';
 
 export {
   Alert,
   Badge,
   Button,
+  ButtonsGroup,
   Card,
   Checkbox,
   Chip,

--- a/src/stories/ButtonsGroup.stories.tsx
+++ b/src/stories/ButtonsGroup.stories.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import ButtonsGroup from '../components/ButtonsGroup/ButtonsGroup';
+
+export default {
+  title: 'Components/ButtonsGroup',
+  component: ButtonsGroup,
+} as ComponentMeta<typeof ButtonsGroup>;
+
+const Template: ComponentStory<typeof ButtonsGroup> = (args, context) => {
+  const [selected, setSelected] = React.useState('One');
+
+  return (
+    <ButtonsGroup onChange={(value) => setSelected(value)} selected={selected} width={args.width}>
+      <ButtonsGroup.Item value={'One'} label={'Last 7 days'} />
+      <ButtonsGroup.Item value={'Two'} label={'Last 30 days'} />
+      <ButtonsGroup.Item value={'Three'} label={'Last 90 days'} />
+      <ButtonsGroup.Item value={'Four'} label={'All'} />
+    </ButtonsGroup>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  selected: 'One',
+  onChange: () => console.log('123'),
+  width: undefined,
+};
+
+export const CustomWidth = Template.bind({});
+CustomWidth.args = {
+  selected: 'One',
+  onChange: () => console.log('123'),
+  width: 600,
+};
+
+export const FullWidth = Template.bind({});
+FullWidth.args = {
+  selected: 'One',
+  onChange: () => console.log('123'),
+  width: 'full',
+};


### PR DESCRIPTION
# Issue
link url
- [BM-302/[Wallet] Transaction history 페이지 > Type에 Convert 항목 추가 요청](https://bclabs.atlassian.net/browse/BM-302)
# What fix
- Convert 탭 표시에 필요한 버튼 탭 컴포넌트 뮤트라이브러리로 공용화하였습니다.
- 피그마링크: https://www.figma.com/file/mDHKwkELe0uoMbtTUYsOHU/%5BCoinvestor%5D-Design-System-Web-v.1.2?type=design&node-id=2498-35447&mode=design&t=kQGIDkejIXEbdGZG-4
# Caution
eg. 후속으로 병합해야하는 PR
- https://github.com/bclabs-org/coinvestor_investor-frontend/pull/1775
# Optional(eg. screenshot)
![스크린샷 2023-12-04 오후 2 17 49](https://github.com/bclabs-org/meut-ui-react/assets/114374519/2fbddc2b-f5c6-4848-9a2e-042cd929cddc)
![스크린샷 2023-12-04 오후 2 12 06](https://github.com/bclabs-org/meut-ui-react/assets/114374519/26ebc2f8-3000-4fb2-8d8e-17e8d16b2eaa)
