### PR TITLE
Feat/CNVSTR-2785/hover/focus/disabled 시 색상 추가, indeterminate 옵션 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { CheckCircleIcon } from '@heroicons/react/20/solid';
+import classNames from 'classnames';
 
 type CheckboxProps = {
   label?: string;
@@ -8,6 +9,7 @@ type CheckboxProps = {
   isComplete?: boolean;
   disabled?: boolean;
   checked?: boolean;
+  indeterminate?: boolean;
   onChange?: () => void;
 };
 
@@ -17,6 +19,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
   disabled = false,
   isComplete,
   checked = false,
+  indeterminate = false,
   onChange,
 }: CheckboxProps) => (
   <>
@@ -54,11 +57,25 @@ const Checkbox: React.FC<CheckboxProps> = ({
               type="checkbox"
               disabled={disabled}
               checked={checked}
-              className="h-4 w-4 border-gray-300 text-primary focus:ring-0 checkbox"
+              className={classNames(
+                'h-4 w-4 border-2 border-gray-300 text-primary rounded-[1px]',
+                'hover:ring-[7px] hover:ring-emerald-100 hover:bg-emerald-100',
+                'active:ring-[7px] active:ring-offset-0 active:ring-emerald-200 active:outline-8 active:bg-emerald-200',
+                'focus:ring-[7px] focus:ring-offset-0 focus:ring-emerald-200 focus:outline-8 focus:bg-emerald-200',
+                'disabled:ring-0 disabled:bg-transparent disabled:opacity-40'
+              )}
               onChange={onChange}
+              ref={(el): void => {
+                const checkbox = el;
+                if (checkbox) checkbox.indeterminate = indeterminate;
+              }}
             />
           </div>
-          <div className="ml-2 text-sm font-medium text-onTertiary">
+          <div
+            className={`ml-2 text-sm font-medium text-onTertiary ${
+              disabled ? 'opacity-40' : 'opacity-100'
+            }`}
+          >
             <label htmlFor="comments">{label}</label>
           </div>
         </div>

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -62,7 +62,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
                 'hover:ring-[7px] hover:ring-emerald-100 hover:bg-emerald-100',
                 'active:ring-[7px] active:ring-offset-0 active:ring-emerald-200 active:outline-8 active:bg-emerald-200',
                 'focus:ring-[7px] focus:ring-offset-0 focus:ring-emerald-200 focus:outline-8 focus:bg-emerald-200',
-                'disabled:ring-0 disabled:bg-transparent disabled:opacity-40'
+                'disabled:ring-0 disabled:opacity-40'
               )}
               onChange={onChange}
               ref={(el): void => {

--- a/src/stories/Checkbox.stories.tsx
+++ b/src/stories/Checkbox.stories.tsx
@@ -9,7 +9,25 @@ export default {
   component: Checkbox,
 } as ComponentMeta<typeof Checkbox>;
 
-const Template: ComponentStory<typeof Checkbox> = (args) => <Checkbox {...args} />;
+const Template: ComponentStory<typeof Checkbox> = (args) => {
+  const [isChecked, setIsChecked] = React.useState(args.checked);
+  const [isChecked2, setIsChecked2] = React.useState(args.checked);
+
+  const handleClick = (): void => {
+    setIsChecked(!isChecked);
+  };
+
+  const handleClick2 = (): void => {
+    setIsChecked2(!isChecked2);
+  };
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <Checkbox {...args} checked={isChecked} onChange={handleClick} label={`${args.label} 1`} />
+      <Checkbox {...args} checked={isChecked2} onChange={handleClick2} label={`${args.label} 2`} />
+    </div>
+  );
+};
 
 export const Default = Template.bind({});
 Default.args = {
@@ -28,4 +46,10 @@ NotClickable.args = {
   label: 'click 안되는 checkbox',
   isDisabled: true,
   isComplete: true,
+};
+
+export const Indeterminate = Template.bind({});
+Indeterminate.args = {
+  label: 'indeterminate checkbox',
+  indeterminate: true,
 };


### PR DESCRIPTION
# Issue
link url
- https://bclabs.atlassian.net/browse/CNVSTR-2785
- https://www.figma.com/file/mDHKwkELe0uoMbtTUYsOHU/%5BCoinvestor%5D-Design-System-Web-v.1.2?type=design&node-id=171-17745&mode=design&t=WIk9BjI1TyamOOo4-4
# What fix
- hover/focus/disabled 시 색상 추가, indeterminate ('-') 옵션 추가

![79dc4f84-1c2c-4574-a1ae-cd33fc1bd4e9](https://github.com/bclabs-org/meut-ui-react/assets/114374519/c5b99b2d-e1a2-4187-b940-64ab5a9bc350)

# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
<img width="203" alt="스크린샷 2023-12-19 오후 2 37 01" src="https://github.com/bclabs-org/meut-ui-react/assets/114374519/14426129-0b21-4bd6-b637-806e38cf508f">
<img width="200" alt="스크린샷 2023-12-19 오후 2 36 49" src="https://github.com/bclabs-org/meut-ui-react/assets/114374519/971db179-2588-465c-973b-e537f83fc2d8">
<img width="195" alt="스크린샷 2023-12-19 오후 2 38 09" src="https://github.com/bclabs-org/meut-ui-react/assets/114374519/7220a852-d972-4b34-9747-1c212dec2e96">
<img width="191" alt="스크린샷 2023-12-19 오후 2 38 00" src="https://github.com/bclabs-org/meut-ui-react/assets/114374519/c9bfbff4-23bf-4869-b8c6-9fab224e9280">
