### PR TITLE
Fix/CNVSTR-2786 radio button group 빌드에러 픽스, 전시 형태 픽스

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -14,7 +14,10 @@ const RadioButton: React.FC<RadioButtonProps> = ({ label, id, disabled }: RadioB
   return (
     <div
       key={id}
-      className={`flex items-center ${labelDirection === 'column' ? 'flex-col' : 'flex-row'}`}
+      className={classNames(
+        'flex ',
+        labelDirection === 'col' ? 'flex-col items-center' : 'flex-row'
+      )}
     >
       <input
         id={id}
@@ -34,7 +37,7 @@ const RadioButton: React.FC<RadioButtonProps> = ({ label, id, disabled }: RadioB
         htmlFor={id}
         className={classNames(
           'block text-sm font-medium leading-5 text-gray-700',
-          labelDirection === 'column' ? 'mt-2' : 'ml-3'
+          labelDirection === 'col' ? 'mt-2' : 'ml-3'
         )}
       >
         {label}

--- a/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -25,7 +25,7 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
     <legend className="sr-only">{legend}</legend>
     <div
       className={classNames(
-        groupDirection === 'row' ? 'flex items-center space-x-4' : 'flex-col space-y-4'
+        groupDirection === 'row' ? 'flex items-center space-x-4' : 'w-fit space-y-4'
       )}
     >
       <RadioButtonGroupContext.Provider value={{ labelDirection, onChange, defaultCheckedId }}>


### PR DESCRIPTION
# Issue
link url

# What fix
- 빌드에러 수정: column -> col 로 오타수정했습니다.
- UI 수정: groupDirection:col, labelDirection:col 일 때 아이템이 화면 왼쪽에 위치하도록 수정했습니다.
# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)

수정 전
<img width="945" alt="스크린샷 2023-12-19 오후 5 04 06" src="https://github.com/bclabs-org/meut-ui-react/assets/114374519/bdf06629-8bc3-4a48-b773-3d62f2bbd379">

수정 후
<img width="249" alt="스크린샷 2023-12-19 오후 5 02 30" src="https://github.com/bclabs-org/meut-ui-react/assets/114374519/a32262ac-b5dc-4df1-a6ee-39ebae46a8e6">