### PR TITLE
Bugfix/CNVSTR-2786/두개 이상의 RadioButtonGroup 컴포넌트를 동시에 사용했을 때 발생하는 문제 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -21,7 +21,7 @@ const RadioButton: React.FC<RadioButtonProps> = ({ label, id, disabled }: RadioB
       )}
     >
       <input
-        id={id}
+        id={`radio-${id}-${legend}`}
         name={`radio-button-${legend}`}
         type="radio"
         defaultChecked={id === defaultCheckedId}
@@ -35,7 +35,7 @@ const RadioButton: React.FC<RadioButtonProps> = ({ label, id, disabled }: RadioB
         disabled={disabled}
       />
       <label
-        htmlFor={id}
+        htmlFor={`radio-${id}-${legend}`}
         className={classNames(
           'block text-sm font-medium leading-5 text-gray-700',
           labelDirection === 'col' ? 'mt-2' : 'ml-3'

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -9,7 +9,8 @@ type RadioButtonProps = {
 };
 
 const RadioButton: React.FC<RadioButtonProps> = ({ label, id, disabled }: RadioButtonProps) => {
-  const { labelDirection, onChange, defaultCheckedId } = React.useContext(RadioButtonGroupContext);
+  const { legend, labelDirection, onChange, defaultCheckedId } =
+    React.useContext(RadioButtonGroupContext);
 
   return (
     <div
@@ -21,7 +22,7 @@ const RadioButton: React.FC<RadioButtonProps> = ({ label, id, disabled }: RadioB
     >
       <input
         id={id}
-        name="notification-method"
+        name={`radio-button-${legend}`}
         type="radio"
         defaultChecked={id === defaultCheckedId}
         className={classNames(

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -17,7 +17,7 @@ const RadioButton: React.FC<RadioButtonProps> = ({ label, id, disabled }: RadioB
       key={id}
       className={classNames(
         'flex ',
-        labelDirection === 'col' ? 'flex-col items-center' : 'flex-row'
+        labelDirection === 'col' ? 'flex-col items-center' : 'flex-row items-center'
       )}
     >
       <input

--- a/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -12,6 +12,10 @@ type RadioButtonGroupProps = {
   onChange: (value: string) => void;
 };
 
+/**
+ * RadioButtonGroup
+ * @caution - legend 값은 컴포넌트마다 고유한 값이어야 합니다. legend 가 같다면 체크상태를 공유하게 됩니다.
+ */
 const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
   legend,
   defaultCheckedId,
@@ -28,7 +32,9 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
         groupDirection === 'row' ? 'flex items-center space-x-4' : 'w-fit space-y-4'
       )}
     >
-      <RadioButtonGroupContext.Provider value={{ labelDirection, onChange, defaultCheckedId }}>
+      <RadioButtonGroupContext.Provider
+        value={{ legend, labelDirection, onChange, defaultCheckedId }}
+      >
         {children}
       </RadioButtonGroupContext.Provider>
     </div>

--- a/src/components/RadioButtonGroup/RadioButtonGroupContext.ts
+++ b/src/components/RadioButtonGroup/RadioButtonGroupContext.ts
@@ -1,12 +1,14 @@
 import React from 'react';
 
 type RadioButtonGroupContextType = {
+  legend: string;
   defaultCheckedId: string;
   labelDirection: 'row' | 'col';
   onChange: (value: string) => void;
 };
 
 const RadioButtonGroupContext = React.createContext<RadioButtonGroupContextType>({
+  legend: '',
   defaultCheckedId: '',
   labelDirection: 'col',
   onChange: () => null,

--- a/src/stories/RadioButtonGroup.stories.tsx
+++ b/src/stories/RadioButtonGroup.stories.tsx
@@ -10,18 +10,37 @@ export default {
 
 const Template: ComponentStory<typeof RadioButtonGroup> = (args) => {
   const [selected, setSelected] = React.useState('1');
+  const [selected2, setSelected2] = React.useState('1');
   const handleChange = (value: string): void => {
     setSelected(value);
   };
 
+  const handleChange2 = (value: string): void => {
+    setSelected2(value);
+  };
+
   return (
     <>
-      <p className="font-medium text-gray-500">Current Select Id: {selected}</p>
+      <p>RadioButtonGroup</p>
+      <p className="mt-1 text-xs font-medium text-gray-500">Current Select Id: {selected}</p>
       <RadioButtonGroup
         {...args}
         onChange={handleChange}
         defaultCheckedId={selected}
         legend="numbers"
+        className="mt-4"
+      >
+        <RadioButton id={'1'} label={'one'} />
+        <RadioButton id={'2'} label={'two'} />
+        <RadioButton id={'3'} label={'three'} />
+      </RadioButtonGroup>
+      <p className="mt-8">RadioButtonGroup 2</p>
+      <p className="mt-1 text-xs font-medium text-gray-500">Current Select Id: {selected2}</p>
+      <RadioButtonGroup
+        {...args}
+        onChange={handleChange2}
+        defaultCheckedId={selected2}
+        legend="numberstwo"
         className="mt-4"
       >
         <RadioButton id={'1'} label={'one'} />


### PR DESCRIPTION
# Issue
link url
- https://bclabs.atlassian.net/browse/CNVSTR-2786
# What fix
- 두 개 이상의 RadioButtonGroup 을 사용했을 때, 다른 그룹의 라디오 버튼과 같은 그룹으로 취급되는 현상 수정했습니다.
   - 동일한 그룹안의 라디오버튼은 같은 name을 가질 수 있도록 Input.name attribute에 legend 값을 넣어주었습니다. 
# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
수정 전
<video src="https://github.com/bclabs-org/meut-ui-react/assets/114374519/b67f3fd3-d704-4e24-a6ba-c09570ecc740"></video>

수정 후
<video src="https://github.com/bclabs-org/meut-ui-react/assets/114374519/d5cce822-c9dd-443a-b508-dd394d04498b"></video>





