### PR TITLE
Refactor/CNVSTR-2806/에러모달 오른쪽 버튼 핸들러 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/Modal/ErrorModal.tsx
+++ b/src/components/Modal/ErrorModal.tsx
@@ -10,6 +10,7 @@ type ModalProps = {
   leftButtonText: string;
   rightButtonText: string;
   leftButtonOnClick: () => void;
+  rightButtonOnClick?: () => void;
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
@@ -18,6 +19,7 @@ const ErrorModal: React.FC<ModalProps> = ({
   message,
   leftButtonText,
   rightButtonText,
+  rightButtonOnClick,
   setIsModalOpen,
   leftButtonOnClick,
 }) => (
@@ -41,7 +43,12 @@ const ErrorModal: React.FC<ModalProps> = ({
         full={true}
         size={`large`}
         color={`primary-error`}
-        onClick={(): void => setIsModalOpen(false)}
+        onClick={(): void => {
+          if (rightButtonOnClick) {
+            rightButtonOnClick();
+          }
+          setIsModalOpen(false);
+        }}
       >
         <p className={`whitespace-nowrap`}>{rightButtonText}</p>
       </Button>

--- a/src/stories/ErrorModal.stories.tsx
+++ b/src/stories/ErrorModal.stories.tsx
@@ -15,7 +15,6 @@ export const Default = Template.bind({});
 Default.args = {
   title: 'Network error',
   message: 'An unknown network error has occured. Please try again later.',
-  isModalOpen: true,
   leftButtonText: 'My purchases',
   rightButtonText: 'Continue browsing',
 };


### PR DESCRIPTION
# Issue
[CNVSTR-2806](https://bclabs.atlassian.net/browse/CNVSTR-2806)

# What fix

코인베스터 공용 에러바운더리 적용을 위해 필요한 작업입니다.

현재 에러 모달 오른쪽 버튼에 모달 닫기 함수만 적용되어 있어 이를 수정하는 작업입니다.

[CNVSTR-2806]: https://bclabs.atlassian.net/browse/CNVSTR-2806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ