### PR TITLE
CNVSTR-2832 #comment 모달 사이즈 large (936px) 추가

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -6,7 +6,7 @@ type ModalProps = {
   children: React.ReactNode;
   isModalOpen: boolean;
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  widthSize?: 'small' | 'medium';
+  widthSize?: 'small' | 'medium' | 'large';
   onOutsideClick?: boolean;
   isCoverHeader?: boolean;
 };
@@ -27,6 +27,9 @@ const Modal: React.FC<ModalProps> = ({
       break;
     case 'medium':
       width = 'w-[718px]';
+      break;
+    case 'large':
+      width = 'w-[936px]';
       break;
     default:
       throw Error('invalid width size pros');


### PR DESCRIPTION
# Issue
[CNVSTR-2832](https://bclabs.atlassian.net/browse/CNVSTR-2832)

# What fix

[모달 디자인](https://www.figma.com/file/TV5T2nwzkQPVRxnrj742nq/%5BCoinvestor%5D-Prototype-Web-v.1.4?type=design&node-id=186-2792&mode=dev)

Earn 페이지에 추가된 모달의 width 사이즈가 추가되어 디자인 라이브러리 모달에 option으로 추가하는 작업입니다.
large = 936px 옵션 추가했습니다.

[CNVSTR-2832]: https://bclabs.atlassian.net/browse/CNVSTR-2832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ