### PR TITLE
Feat / CNVSTR-2868 / Modal 컴포넌트에 onClose 프롭 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -8,6 +8,7 @@ type ModalProps = {
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
   widthSize?: 'small' | 'medium';
   onOutsideClick?: boolean;
+  onClose?: Function;
   isCoverHeader?: boolean;
 };
 
@@ -17,6 +18,7 @@ const Modal: React.FC<ModalProps> = ({
   setIsModalOpen,
   widthSize = 'medium',
   onOutsideClick = true,
+  onClose,
   isCoverHeader = false,
 }) => {
   let width: string;
@@ -37,7 +39,7 @@ const Modal: React.FC<ModalProps> = ({
       <Dialog
         as="div"
         className={`relative ${isCoverHeader ? 'z-30' : 'z-10'}`}
-        onClose={() => setIsModalOpen(!onOutsideClick)}
+        onClose={(e) => (onClose ? onClose(e) : setIsModalOpen(!onOutsideClick))}
       >
         <Transition.Child
           as={Fragment}


### PR DESCRIPTION
# Issue
link url
- https://bclabs.atlassian.net/browse/CNVSTR-2868
# What fix
-  https://bclabs.atlassian.net/browse/CNVSTR-2867 ← 해당 일감에서 모달 외 영역 클릭 시 리다이렉트 동작 구현을 위해 <Modal/> 컴포넌트에 모달이 닫힐 때 이벤트를 제어할 수 있도록 onClose 프롭 추가했습니다.
# Caution
eg. 먼저 병합해야하는 PR

# Optional(eg. screenshot)
