### PR TITLE
Refactor/cnvstr 2870/error modal props 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/Modal/ErrorModal.tsx
+++ b/src/components/Modal/ErrorModal.tsx
@@ -12,6 +12,7 @@ type ModalProps = {
   leftButtonOnClick: () => void;
   rightButtonOnClick?: () => void;
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  children?: React.ReactNode;
 };
 
 const ErrorModal: React.FC<ModalProps> = ({
@@ -22,6 +23,7 @@ const ErrorModal: React.FC<ModalProps> = ({
   rightButtonOnClick,
   setIsModalOpen,
   leftButtonOnClick,
+  children,
 }) => (
   <div className="flex flex-col gap-6">
     <div className="flex flex-col gap-5 items-center ">
@@ -33,6 +35,7 @@ const ErrorModal: React.FC<ModalProps> = ({
       <div className={`flex flex-col items-center justify-center gap-2`}>
         <p className={`text-base text-gray-900 font-semibold`}>{title}</p>
         <p className={`text-sm font-normal text-center`}>{message}</p>
+        {children}
       </div>
     </div>
     <div className={`flex items-center justify-center w-full gap-3`}>

--- a/src/components/Modal/ErrorModal.tsx
+++ b/src/components/Modal/ErrorModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 
+import { XMarkIcon } from '@heroicons/react/20/solid';
 import Button from '../Button';
 
 type ModalProps = {
@@ -12,6 +13,7 @@ type ModalProps = {
   leftButtonOnClick: () => void;
   rightButtonOnClick?: () => void;
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isXButton?: boolean;
   children?: React.ReactNode;
 };
 
@@ -24,8 +26,19 @@ const ErrorModal: React.FC<ModalProps> = ({
   setIsModalOpen,
   leftButtonOnClick,
   children,
+  isXButton,
 }) => (
-  <div className="flex flex-col gap-6">
+  <div className="relative flex flex-col gap-6">
+    {isXButton && (
+      <button
+        className={`absolute top-0 right-0`}
+        type="button"
+        onClick={() => setIsModalOpen(false)}
+        aria-label="Close Modal"
+      >
+        <XMarkIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
+      </button>
+    )}
     <div className="flex flex-col gap-5 items-center ">
       <div>
         <div className={`p-3 bg-pink-50 rounded-full`}>


### PR DESCRIPTION
# Issue
[CNVSTR-2870](https://bclabs.atlassian.net/browse/CNVSTR-2870)

# What fix
- Error Modal에 children, 닫기 버튼 props 옵션 추가

# Optional(eg. screenshot)
![스크린샷 2024-02-20 15 47 18](https://github.com/bclabs-org/meut-ui-react/assets/117155299/4ecaf8d6-5949-4089-a2be-b637c4e002c1)


[CNVSTR-2870]: https://bclabs.atlassian.net/browse/CNVSTR-2870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ