### PR TITLE
Refactor/modal padding size optional props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 
 import { Dialog, Transition } from '@headlessui/react';
+import getPadding from './util';
 
 type ModalProps = {
   children: React.ReactNode;
@@ -10,6 +11,7 @@ type ModalProps = {
   onOutsideClick?: boolean;
   onClose?: Function;
   isCoverHeader?: boolean;
+  customPadding?: string;
 };
 
 const Modal: React.FC<ModalProps> = ({
@@ -20,6 +22,7 @@ const Modal: React.FC<ModalProps> = ({
   onOutsideClick = true,
   onClose,
   isCoverHeader = false,
+  customPadding,
 }) => {
   let width: string;
 
@@ -36,6 +39,8 @@ const Modal: React.FC<ModalProps> = ({
     default:
       throw Error('invalid width size pros');
   }
+
+  const padding = getPadding(customPadding);
 
   return (
     <Transition.Root show={isModalOpen} as={Fragment}>
@@ -77,7 +82,7 @@ const Modal: React.FC<ModalProps> = ({
               <Dialog.Panel
                 className={`${width} relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all h-fit`}
               >
-                <div className="py-8 px-10">{children}</div>
+                <div className={padding}>{children}</div>
               </Dialog.Panel>
             </Transition.Child>
           </div>

--- a/src/components/Modal/util.ts
+++ b/src/components/Modal/util.ts
@@ -1,0 +1,8 @@
+const getPadding = (customPadding?: string) => {
+  if (customPadding) {
+    return customPadding;
+  }
+  return 'px-10 py-8';
+};
+
+export default getPadding;


### PR DESCRIPTION
# What fix
모달의 커스텀 패딩을 더할 수 있는 유틸과 props를 추가했습니다.

# Optional(eg. screenshot)
``` 
<Modal
        isModalOpen={isModalOpen}
        setIsModalOpen={setIsModalOpen}
        widthSize={modalSize}
        isCoverHeader={true}
        onOutsideClick={false}
        customPadding={`px-5 py-6`}
      >
```

![스크린샷 2024-02-21 19 03 26](https://github.com/bclabs-org/meut-ui-react/assets/117155299/76425535-0bd5-4053-ac65-f9d3145aa0eb)
