### PR TITLE
Refactor/toast 컬러 변경 및 closeBtn 옵션 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -35,7 +35,6 @@ const Alert: React.FC<AlertProps> = ({
 }: AlertProps) => {
   let alertBackground;
   let alertIcon;
-  let alertCloseBtn;
   let alertText;
   let alertSubText;
   switch (color) {
@@ -44,7 +43,6 @@ const Alert: React.FC<AlertProps> = ({
         alertBackground = 'bg-pink-50';
       }
       alertIcon = 'text-warning';
-      alertCloseBtn = 'text-warning';
       alertText = 'text-pink-800';
       alertSubText = 'text-pink-700';
       break;
@@ -53,7 +51,6 @@ const Alert: React.FC<AlertProps> = ({
         alertBackground = 'bg-amber-50';
       }
       alertIcon = 'text-amber-400';
-      alertCloseBtn = 'text-amber-600';
       alertText = 'text-amber-800';
       alertSubText = 'text-amber-700';
       break;
@@ -62,7 +59,6 @@ const Alert: React.FC<AlertProps> = ({
         alertBackground = 'bg-secondary';
       }
       alertIcon = 'text-emerald-400';
-      alertCloseBtn = 'text-primary';
       alertText = 'text-emerald-800';
       alertSubText = 'text-emerald-700';
       break;
@@ -71,7 +67,6 @@ const Alert: React.FC<AlertProps> = ({
         alertBackground = 'bg-blue-50';
       }
       alertIcon = 'text-blue-400';
-      alertCloseBtn = 'text-blue-700';
       alertText = 'text-blue-800';
       alertSubText = 'text-blue-800';
       break;

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -50,12 +50,12 @@ const Alert: React.FC<AlertProps> = ({
       break;
     case 'attention':
       if (isBackgroundShow) {
-        alertBackground = 'bg-yellow-50';
+        alertBackground = 'bg-amber-50';
       }
-      alertIcon = 'text-yellow-400';
-      alertCloseBtn = 'text-yellow-600';
-      alertText = 'text-yellow-800';
-      alertSubText = 'text-yellow-700';
+      alertIcon = 'text-amber-400';
+      alertCloseBtn = 'text-amber-600';
+      alertText = 'text-amber-800';
+      alertSubText = 'text-amber-700';
       break;
     case 'completion':
       if (isBackgroundShow) {

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -79,7 +79,7 @@ const Toast: React.FC<ToastProps> = ({ toastState, index, onHeightReady, top }: 
         subText={toastState.subMessage}
         color={toastState.type as 'error'}
         setIsAlertOpen={(): void => setIsCloseAnimationPlay(true)}
-        closeBtn
+        closeBtn={toastState.closeBtn}
       />
     </div>
   );

--- a/src/components/Toast/ToastStore.ts
+++ b/src/components/Toast/ToastStore.ts
@@ -4,12 +4,18 @@ let toasts: ToastState[] = [];
 let listeners: Function[] = [];
 
 const toastStore = {
-  addToast(message: string, type: ToastColor, subMessage: string, duration: number): void {
+  addToast(
+    message: string,
+    type: ToastColor,
+    subMessage: string,
+    duration: number,
+    closeBtn = true
+  ): void {
     const isMessageExists = toasts.some((t) => t.message === message);
     if (isMessageExists) {
       return;
     }
-    toasts = [...toasts, { message, type, subMessage, duration }];
+    toasts = [...toasts, { message, type, subMessage, duration, closeBtn }];
     listeners.forEach((listener) => listener(toasts));
   },
   subscribe(listener: Function): () => void {
@@ -30,17 +36,31 @@ const toastStore = {
   },
 };
 
-const toast = (message: string, type: ToastColor, subMessage = '', duration = 2000): void => {
-  toastStore.addToast(message, type, subMessage, duration);
+const toast = (
+  message: string,
+  type: ToastColor,
+  subMessage = '',
+  duration = 2000,
+  closeBtn = true
+): void => {
+  toastStore.addToast(message, type, subMessage, duration, closeBtn);
 };
 
-toast.error = (message: string, subMessage?: string, duration?: number): void =>
-  toast(message, 'error', subMessage, duration);
-toast.attention = (message: string, subMessage?: string, duration?: number): void =>
-  toast(message, 'attention', subMessage, duration);
-toast.completion = (message: string, subMessage?: string, duration?: number): void =>
-  toast(message, 'completion', subMessage, duration);
-toast.info = (message: string, subMessage?: string, duration?: number): void =>
-  toast(message, 'information', subMessage, duration);
+toast.error = (message: string, subMessage?: string, duration?: number, closeBtn = true): void =>
+  toast(message, 'error', subMessage, duration, closeBtn);
+toast.attention = (
+  message: string,
+  subMessage?: string,
+  duration?: number,
+  closeBtn = true
+): void => toast(message, 'attention', subMessage, duration, closeBtn);
+toast.completion = (
+  message: string,
+  subMessage?: string,
+  duration?: number,
+  closeBtn = true
+): void => toast(message, 'completion', subMessage, duration, closeBtn);
+toast.info = (message: string, subMessage?: string, duration?: number, closeBtn = true): void =>
+  toast(message, 'information', subMessage, duration, closeBtn);
 
 export { toastStore, toast };

--- a/src/components/Toast/types.ts
+++ b/src/components/Toast/types.ts
@@ -5,4 +5,5 @@ export type ToastState = {
   subMessage?: string;
   type: ToastColor;
   duration?: number;
+  closeBtn?: boolean;
 };

--- a/src/stories/Toast.stories.tsx
+++ b/src/stories/Toast.stories.tsx
@@ -23,9 +23,10 @@ type ToastOptionProps = {
     displayText: string;
     onClick: () => void;
     codeText?: string;
+    closeBtn?: boolean;
 };
 
-const ToastOption: React.FC<ToastOptionProps> = ({ toastType, displayText, onClick, codeText }) => (
+const ToastOption: React.FC<ToastOptionProps> = ({ toastType, displayText, onClick, codeText,  }) => (
         <div className="py-2 flex flex-col gap-y-2">
             <code className="w-fit rounded bg-gray-100 text-xs p-1">
                 {codeText || `toast.${toastType}('message', 'subMessage')`}
@@ -91,6 +92,12 @@ const Template: ComponentStory<typeof React.Component<DefaultArgs>> = (args) => 
                         displayText="Popup attention"
                         onClick={() => toast.attention('attention msg', '', 1000)}
                         codeText="toast.attention('attention msg', '', 1000)"
+                    />
+                    <ToastOption
+                        toastType="attention"
+                        displayText="Popup attention - no close button"
+                        onClick={() => toast.attention('attention msg - no close button', '', 1000, false)}
+                        codeText="toast.attention('attention msg - no close button', '', 1000)"
                     />
                     <ToastOption
                         toastType="error"


### PR DESCRIPTION
# Issue
[CICK-18](https://bclabs.atlassian.net/browse/CICK-18)

# What fix
![image](https://github.com/bclabs-org/meut-ui-react/assets/117155299/c0c53446-791d-49d3-9cbe-977a989d9606)

- alert attention 색상이 yellow -> amber로 변경되어 반영했습니다.
- 해당 alert에 close button이 없어 toast()의 마지막 매개변수로 추가했습니다. default true로 주어서 기존 alert에는 영향 없앴습니다.
- ToastStore, Toast, Alert 수정했습니다.

# Optional(eg. screenshot)

### 스토리북

| closeBtn 디폴트 |
|-----|
| ![스크린샷 2024-03-26 16 16 43](https://github.com/bclabs-org/meut-ui-react/assets/117155299/77edbf67-0c7d-4ad7-8098-b4ac47722a1d) |

| closeBtn = false |
|-----|
| ![스크린샷 2024-03-26 16 12 19](https://github.com/bclabs-org/meut-ui-react/assets/117155299/e7f270d2-92d2-443a-b666-4e1fe61278a0) |




[CICK-18]: https://bclabs.atlassian.net/browse/CICK-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ