### PR TITLE
Refactor/modal custom size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bclabs-org/meut-ui-react",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "scripts": {
     "build": "rm -rf dist && rm -rf lib && rollup -c",
     "watch": "rollup -cw",

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 
 import { Dialog, Transition } from '@headlessui/react';
+import classNames from 'classnames';
 import getPadding from './util';
 
 type ModalProps = {
@@ -12,6 +13,7 @@ type ModalProps = {
   onClose?: Function;
   isCoverHeader?: boolean;
   customPadding?: string;
+  customDialogWrapper?: string;
 };
 
 const Modal: React.FC<ModalProps> = ({
@@ -23,6 +25,7 @@ const Modal: React.FC<ModalProps> = ({
   onClose,
   isCoverHeader = false,
   customPadding,
+  customDialogWrapper,
 }) => {
   let width: string;
 
@@ -83,7 +86,11 @@ const Modal: React.FC<ModalProps> = ({
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
               <Dialog.Panel
-                className={`${width} relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all h-fit`}
+                className={classNames(
+                  `relative transform overflow-hidden`,
+                  customDialogWrapper ||
+                    `${width} rounded-lg bg-white text-left shadow-xl transition-all h-fit`
+                )}
               >
                 <div className={padding}>{children}</div>
               </Dialog.Panel>


### PR DESCRIPTION
# Issue
[CICK-46](https://bclabs.atlassian.net/browse/CICK-46)

# What fix

Earn 이벤트 팝업 가로 사이즈 및 패딩, 보더 라운드 미적용되었습니다. 
다이얼로그 커스텀 클래스를 추가하여 Modal 컴포넌트 사용할 수 있게했습니다.

# Optional(eg. screenshot)
![image](https://github.com/bclabs-org/meut-ui-react/assets/117155299/2a84640b-4387-478a-b02c-410d84a6182c)


[CICK-46]: https://bclabs.atlassian.net/browse/CICK-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ